### PR TITLE
ハンズオンラーニングセンターの名称変更に対応

### DIFF
--- a/define.py
+++ b/define.py
@@ -55,7 +55,7 @@ ad_data = [
     "国際教育・協力センター/CIEC／Center for International Education and Cooperation",
     "キリスト教と文化研究センター／Research Center for Christianity and Culture",
     "日本語教育センター／Center for Japanese Language Education",
-    "ハンズオン・ラーニングセンター／Hands-on Learning Center",
+    "共通教育センター（ハンズオン・ラーニング科目）／Common Education Center (Hands-on Learning Programs)",
     "国連・外交統括センター／Integrated Center for UN and Foreign Affairs Studies",
     "神学研究科前期／Graduate School of Theology Master's Course",
     "文学研究科前期／Graduate School of Humanities Master's Course",

--- a/make.py
+++ b/make.py
@@ -51,7 +51,7 @@ for i in range(16, 59):
     "国際教育・協力センター/CIEC","Center for International Education and Cooperation",
     "キリスト教と文化研究センター","Research Center for Christianity and Culture",
     "日本語教育センター","Center for Japanese Language Education",
-    "ハンズオン・ラーニングセンター","Center for Hands-on Learning Programs",
+    "共通教育センター（ハンズオン・ラーニング科目）","Common Education Center (Hands-on Learning Programs)",
     "国連・外交統括センター","Integrated Center for UN and Foreign Affairs Studies",
     "神学研究科前期","Graduate School of Theology Master's Course",
     "文学研究科前期","Graduate School of Humanities Master's Course",


### PR DESCRIPTION
旧: ハンズオン・ラーニングセンター／Hands-on Learning Center
新: 共通教育センター（ハンズオン・ラーニング科目）／Common Education Center (Hands-on Learning Programs)

サイト上の名称変更によりsafe_index()がマッチせず管理部署が保存されないバグを修正